### PR TITLE
Post only a single PR comment

### DIFF
--- a/.github/workflows/publish-report.yml
+++ b/.github/workflows/publish-report.yml
@@ -23,6 +23,12 @@ on:
       artifact_name:
         description: Name of artifact to be downloaded.
         required: true
+      woo_repo:
+        description: Repository that triggered this workflow.
+        default: woocommerce/woocommerce
+      woo_repo_owner:
+        description: Owner of woo_repo.
+        default: woocommerce
       pr_number:
         description: If test_workflow is 'pr', this is the WooCommerce PR that generated the test report.
       commit_sha:
@@ -39,13 +45,15 @@ jobs:
       ARTIFACT_NAME: ${{ github.event.inputs.artifact_name }}
       PR_NUMBER: ${{ github.event.inputs.pr_number }}
       COMMIT_SHA: ${{ github.event.inputs.commit_sha }}
+      WOO_REPO: ${{ github.event.inputs.woo_repo }}
+      WOO_REPO_OWNER: ${{ github.event.inputs.woo_repo_owner }}
       DOWNLOAD_PATH: ${{ github.workspace }}/download
       REPO_PATH: ${{ github.workspace }}/repo
       GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Validate PR number
         if: ${{ github.event.inputs.test_workflow == 'pr' }}
-        run: gh pr view $PR_NUMBER --repo woocommerce/woocommerce >> /dev/null
+        run: gh pr view $PR_NUMBER --repo $WOO_REPO >> /dev/null
 
       - name: Create dirs
         run: |
@@ -84,4 +92,7 @@ jobs:
         working-directory: ${{ env.REPO_PATH }}/.github/workflows/scripts
         env:
           GITHUB_TOKEN: ${{ secrets.REPORTS_TOKEN }}
+          REPORTS_REPO: ${{ github.repository }}
+          REPORTS_REPO_OWNER: ${{ github.repository_owner }}
+          REPORTS_USER: ${{ secrets.REPORTS_USER }}
         run: bash add-pr-comment.sh

--- a/.github/workflows/scripts/add-pr-comment.sh
+++ b/.github/workflows/scripts/add-pr-comment.sh
@@ -1,18 +1,45 @@
 #!/usr/bin/env bash
 
-# Get the comment body as a variable
-COMMENT_BODY=$(cat templates/COMMENT_TEMPLATE.md)
+COMMENT_BODY=""
+COMMENT_ID=""
 
-# Replace variables in comment body
-COMMENT_BODY=${COMMENT_BODY//COMMIT_SHA/$COMMIT_SHA}
-COMMENT_BODY=${COMMENT_BODY//COMMIT_MESSAGE/$COMMIT_MESSAGE}
-COMMENT_BODY=${COMMENT_BODY//PR_NUMBER/$PR_NUMBER}
+set_comment_body() {
+    REPORTS_REPO_NAME=${REPORTS_REPO#"$REPORTS_REPO_OWNER/"}
+    COMMENT_BODY=$(cat templates/COMMENT_TEMPLATE.md)
+    COMMENT_BODY=${COMMENT_BODY//COMMIT_SHA/$COMMIT_SHA}
+    COMMENT_BODY=${COMMENT_BODY//COMMIT_MESSAGE/$COMMIT_MESSAGE}
+    COMMENT_BODY=${COMMENT_BODY//PR_NUMBER/$PR_NUMBER}
+    COMMENT_BODY=${COMMENT_BODY//REPORTS_REPO_NAME/$REPORTS_REPO_NAME}
+    COMMENT_BODY=${COMMENT_BODY//REPORTS_REPO/$REPORTS_REPO}
+    COMMENT_BODY=${COMMENT_BODY//WOO_REPO_OWNER/$WOO_REPO_OWNER}
 
-# Display comment body to user
-echo "Comment to be posted on pull request #$PR_NUMBER:"
-echo "\n\n"
-echo "$COMMENT_BODY"
-echo "\n\n"
+    echo "Comment to be posted on pull request #$PR_NUMBER:"
+    echo "$COMMENT_BODY"
+}
 
-# Add the comment to the pull request
-gh pr comment $PR_NUMBER --repo=woocommerce/woocommerce --body "$COMMENT_BODY"
+get_comment_id() {
+    # This command will look for existing PR comments by botwoo, and whose body contains:
+    # "Test reports for ... have been published"
+    # And will return an array of comment id's.
+    # The first id in the array will be saved as COMMENT_ID.
+    COMMENT_ID=$(gh api repos/$WOO_REPO/issues/$PR_NUMBER/comments \
+        --jq "[.[] | select((.user.login == \"$REPORTS_USER\") and (.body | test(\".*Test reports for .* have been published\"))) | .id][0]")
+}
+
+add_comment() {
+    gh pr comment $PR_NUMBER --repo=$WOO_REPO --body "$COMMENT_BODY"
+}
+
+update_comment() {
+    gh api -X PATCH repos/$WOO_REPO/issues/comments/$COMMENT_ID -f body="$COMMENT_BODY"
+}
+
+set_comment_body
+
+get_comment_id
+
+if [[ -z "$COMMENT_ID" ]]; then
+    add_comment
+else
+    update_comment
+fi

--- a/.github/workflows/scripts/download-report.sh
+++ b/.github/workflows/scripts/download-report.sh
@@ -11,7 +11,7 @@ for ((i = 1; i <= $MAX_ATTEMPTS; i++)); do
     echo "Downloading $ARTIFACT_NAME (try #$i)..."
     gh run download $RUN_ID \
         --name $ARTIFACT_NAME \
-        --repo woocommerce/woocommerce
+        --repo $WOO_REPO
 
     EXIT_CODE=$(echo $?)
 

--- a/.github/workflows/scripts/get-commit-message.sh
+++ b/.github/workflows/scripts/get-commit-message.sh
@@ -7,7 +7,7 @@
 
 # Get the commit message using GitHub CLI
 COMMIT_MESSAGE=$(gh pr view $PR_NUMBER \
-    --repo woocommerce/woocommerce \
+    --repo $WOO_REPO \
     --json commits \
     --jq ".commits[] | select(.oid == \"$COMMIT_SHA\") | .messageHeadline")
 

--- a/.github/workflows/scripts/regenerate-report.sh
+++ b/.github/workflows/scripts/regenerate-report.sh
@@ -99,8 +99,8 @@ set_jekyll_front_matter() {
 
         # Get the URL-encoded PR title.
         # URL encoding ensures special characters in PR titles will not cause any trouble when processed by Jekyll.
-        PR_TITLE_ENCODED=$(gh pr view $PR_NUMBER --repo woocommerce/woocommerce --json title --jq '.title|@uri')
-
+        PR_TITLE_ENCODED=$(gh pr view $PR_NUMBER --repo $WOO_REPO --json title --jq '.title|@uri')
+        
         # Variable to be used as basis for sorting the "Pull requests" list in homepage.
         LAST_PUBLISHED=$(date +'%Y-%m-%d %T %z')
 

--- a/.github/workflows/scripts/templates/COMMENT_TEMPLATE.md
+++ b/.github/workflows/scripts/templates/COMMENT_TEMPLATE.md
@@ -1,6 +1,11 @@
-:bar_chart: Test reports for COMMIT_SHA `COMMIT_MESSAGE` have been published and are accessible through the following links:
+:bar_chart: Test reports for this pull request have been published and are accessible through the following links:
 
-- [REST API Test Report](https://woocommerce.github.io/woocommerce-test-reports/pr/PR_NUMBER/api/)
+- [REST API Test Report](https://WOO_REPO_OWNER.github.io/REPORTS_REPO_NAME/pr/PR_NUMBER/api/)
 - E2E Test Report (TBC)
 
-Visit the [WooCommerce Test Reports](https://woocommerce.github.io/woocommerce-test-reports) homepage to view all published reports. See the [FAQs](https://github.com/woocommerce/woocommerce-test-reports/wiki/FAQs) page if you're having problems accessing them.
+Latest commit referenced in the reports: `COMMIT_MESSAGE` COMMIT_SHA
+This comment will automatically be updated with the latest referenced commit when you push new changes to this pull request.
+
+---
+
+_Visit the [WooCommerce Test Reports](https://WOO_REPO_OWNER.github.io/REPORTS_REPO_NAME) homepage to view all published reports. See the [FAQs](https://github.com/REPORTS_REPO/wiki/FAQs) page if you're having problems accessing them._


### PR DESCRIPTION
Closes 275-gh-woocommerce/woocommerce-quality

Currently, PR comments are created every time the PR author pushes new commits, like so:

<img width="933" alt="Screen Shot 2022-05-17 at 7 32 52 PM" src="https://user-images.githubusercontent.com/4509348/168801509-cc95ab14-8be4-4fbd-8d32-f271c4ec16c1.png">

This could result in a spammy behavior in the PR comments. 

This PR aims to create only 1 PR comment that will be updated every time new changes are pushed to the pull request