### PR TITLE
Handle null duration/error in api and e2e stats

### DIFF
--- a/.github/workflows/scripts/update-api-stats.js
+++ b/.github/workflows/scripts/update-api-stats.js
@@ -5,7 +5,7 @@ const credentials = require('./key.json');
 
 // Extract the required information
 const { total, skipped, broken, failed } = data.statistic;
-const duration = data.time.duration / 1000;
+const duration = ( data.time.duration ?? 0 ) / 1000;
 const dateObj = new Date();
 const formattedDate = dateObj.toLocaleDateString('en-GB', {
   day: 'numeric',

--- a/.github/workflows/scripts/update-e2e-stats.js
+++ b/.github/workflows/scripts/update-e2e-stats.js
@@ -5,7 +5,7 @@ const credentials = require('./key.json');
 
 // Extract the required information
 const { total, skipped, broken, failed } = data.statistic;
-const duration = data.time.duration / 1000;
+const duration = ( data.time.duration ?? 0 ) / 1000;
 const dateObj = new Date();
 const formattedDate = dateObj.toLocaleDateString('en-GB', {
   day: 'numeric',


### PR DESCRIPTION
Puts in a check to make sure we have a duration, otherwise assign it a value of 0