### PR TITLE
Add script to generate the list of tests

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -134,3 +134,10 @@ jobs:
           echo "::group::Update runs"
           node ./bin/update-runs-data.js
           echo "::endgroup::"
+
+      - name: Update flows list
+        if: ${{ inputs.event == 'push' }}
+        run: |
+          echo "::group::Update flows list"
+          node ./bin/generate-tests-list.js
+          echo "::endgroup::"

--- a/bin/generate-tests-list.js
+++ b/bin/generate-tests-list.js
@@ -1,0 +1,80 @@
+/**
+ * This script will generate a list of tests from the Playwright json reports.
+ */
+
+const { s3Params, s3client } = require( './s3-client' );
+const { PutObjectCommand } = require( '@aws-sdk/client-s3' );
+const { readdirSync, readFileSync } = require( 'node:fs' );
+const path = require( 'path' );
+
+const { REF_NAME, COMMIT_SHA, RESULTS_PATH } = process.env;
+const reportFileName = `flows-coverage${ REF_NAME ? '-' + REF_NAME : '' }`;
+const jsonFilePath = `data/${ reportFileName }.json`;
+
+( async () => {
+	const data = { flows: [], ref: REF_NAME ? REF_NAME : 'unknown', sha: COMMIT_SHA ? COMMIT_SHA : 'unknown', lastUpdate: new Date() };
+
+	const fileSuites = getSuitesData( RESULTS_PATH, /^test-results-\d+\.json$/ );
+	data.flows = getUniqueNestedTitles( fileSuites.flat() );
+
+	// Write the file locally
+	const { writeJson } = require( './utils' );
+	writeJson( data, path.join( '', jsonFilePath ) );
+
+	// Upload the report to S3
+	const cmd = new PutObjectCommand( {
+		Bucket: s3Params.Bucket,
+		Key: jsonFilePath,
+		Body: JSON.stringify( data ),
+		ContentType: 'application/json',
+	} );
+	// await s3client.send( cmd );
+} )();
+
+function getSuitesData( jsonReportsPath, fileNamePattern ) {
+	const suites = [];
+	const files = readdirSync( jsonReportsPath );
+	const jsonFiles = files.filter( file => fileNamePattern.test( file ) );
+
+	jsonFiles.forEach( file => {
+		const filePath = path.join( jsonReportsPath, file );
+		const fileContent = readFileSync( filePath, 'utf-8' );
+		const jsonData = JSON.parse( fileContent );
+		suites.push( jsonData.suites );
+	} );
+
+	return suites;
+}
+
+function getUniqueNestedTitles( suites, depth = 0, parentTitle = '' ) {
+	if ( depth > 100 ) return [];
+
+	let titles = [];
+	let skippedTitles = [];
+
+	suites.forEach( suite => {
+		const isFileSuite = suite.title === suite.file;
+		const currentSuiteTitle = isFileSuite ? '' : suite.title;
+		const currentTitle = parentTitle
+			? `${ parentTitle } > ${ currentSuiteTitle }`
+			: currentSuiteTitle;
+
+		// Add specs titles
+		suite.specs.forEach( spec => {
+			const test = {
+				title: `${ currentTitle ? currentTitle + ' --> ' : '' }${ spec.title }`,
+				file: suite.file,
+				line: suite.line,
+				skipped: spec.tests.every( test => test.expectedStatus === 'skipped' ),
+			}
+			titles.push( test );
+		} );
+
+		// Recursively add nested suites titles
+		if ( suite.suites && suite.suites.length > 0 ) {
+			titles = titles.concat( getUniqueNestedTitles( suite.suites, depth + 1, currentTitle ) );
+		}
+	} );
+
+	return titles.sort();
+}


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce/issues/48935

Added `./bin/generate-tests-list.js` to generate a json file with a list of tests.
Updated the reports workflow to call this script when the event is `push`. We only want to generate this list for trunk or release branches.