### PR TITLE
Fix for nested suites not being displayed if there are flows at the same level

### DIFF
--- a/src/components/Flows.js
+++ b/src/components/Flows.js
@@ -69,6 +69,8 @@ export default class Flows extends BaseComponent {
 
 		this.data.flows = this.groupFlowsByNestedSuites( filteredFlows );
 
+		console.log( this.data.flows );
+
 		this.data.count = count;
 		this.data.sha = this.rawData.sha;
 		this.data.ref = this.rawData.ref;
@@ -289,6 +291,13 @@ export default class Flows extends BaseComponent {
 							<div
 								className={ 'suiteTitleContainer' }
 								onClick={ () => this.toggleVisibility( suiteIndex ) }
+								role="button"
+								tabIndex={ 0 }
+								onKeyPress={ e => {
+									if ( e.key === 'Enter' ) {
+										this.toggleVisibility( suiteIndex );
+									}
+								} }
 							>
 								<span className={ 'suiteTitle' }>{ suiteName }</span>
 								<svg
@@ -305,9 +314,14 @@ export default class Flows extends BaseComponent {
 								</svg>
 							</div>
 							<div id={ `suite-${ suiteIndex }` }>
-								{ suiteData.flows
-									? this.renderFlowsList( suiteData.flows )
-									: this.renderSuites( suiteData, `${ suiteIndex }-` ) }
+								{ suiteData.flows && this.renderFlowsList( suiteData.flows ) }
+								{ Object.entries( suiteData ).filter( ( [ key ] ) => key !== 'flows' ).length > 0 &&
+									this.renderSuites(
+										Object.fromEntries(
+											Object.entries( suiteData ).filter( ( [ key ] ) => key !== 'flows' )
+										),
+										`${ suiteIndex }-`
+									) }
 							</div>
 						</li>
 					);


### PR DESCRIPTION
If a suite has tests and other sub-suites at the same level, the nested suites are not being displayed in the Flows page.

![capture 2025-02-26 at 17 21 01](https://github.com/user-attachments/assets/0daab88f-9013-45f9-9d32-5a41dae0ae56)

After the fix:

![capture 2025-02-26 at 17 21 14](https://github.com/user-attachments/assets/301d1293-5122-4264-b524-054fc138ab83)
